### PR TITLE
Fixes encryption after app restart

### DIFF
--- a/noodle/src/main/java/com/noodle/storage/RandomAccessFileStorage.java
+++ b/noodle/src/main/java/com/noodle/storage/RandomAccessFileStorage.java
@@ -157,7 +157,7 @@ public class RandomAccessFileStorage implements Storage {
   private Record encryptRecord(final Record original) {
     try {
       return new Record(
-          encryption.encrypt(original.key),
+          original.key,
           encryption.encrypt(original.data)
       );
     } catch (Exception e) {
@@ -183,7 +183,7 @@ public class RandomAccessFileStorage implements Storage {
   private Record decryptRecord(final Record encrypted) {
     try {
       return new Record(
-          encryption.decrypt(encrypted.key),
+          encrypted.key,
           encryption.decrypt(encrypted.data)
       );
     } catch (Exception e) {
@@ -237,8 +237,7 @@ public class RandomAccessFileStorage implements Storage {
           throw new RuntimeException("Data is corrupted at " + file.getFilePointer());
         }
 
-        final byte[] decryptedKey = encryption.decrypt(key);
-        index.put(new BytesWrapper(decryptedKey), pos);
+        index.put(new BytesWrapper(key), pos);
 
         file.seek(file.getFilePointer() + dataSize);
       }

--- a/noodle/src/main/java/com/noodle/storage/RandomAccessFileStorage.java
+++ b/noodle/src/main/java/com/noodle/storage/RandomAccessFileStorage.java
@@ -38,7 +38,7 @@ public class RandomAccessFileStorage implements Storage {
       }
 
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw toRuntimeException(e);
     }
   }
 
@@ -65,7 +65,7 @@ public class RandomAccessFileStorage implements Storage {
 
         index.put(new BytesWrapper(key), pos);
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        throw toRuntimeException(e);
       }
     }
   }
@@ -123,7 +123,7 @@ public class RandomAccessFileStorage implements Storage {
 
         return decryptRecord(encryptedRecord);
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        throw toRuntimeException(e);
       }
     }
   }
@@ -161,7 +161,7 @@ public class RandomAccessFileStorage implements Storage {
           encryption.encrypt(original.data)
       );
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw toRuntimeException(e);
     }
   }
 
@@ -187,7 +187,7 @@ public class RandomAccessFileStorage implements Storage {
           encryption.decrypt(encrypted.data)
       );
     } catch (Exception e) {
-      throw new RuntimeException(e);
+      throw toRuntimeException(e);
     }
   }
 
@@ -207,7 +207,7 @@ public class RandomAccessFileStorage implements Storage {
       return new Record(keyBytes, dataBytes);
 
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw toRuntimeException(e);
     }
   }
 
@@ -242,5 +242,12 @@ public class RandomAccessFileStorage implements Storage {
         file.seek(file.getFilePointer() + dataSize);
       }
     }
+  }
+
+  /**
+   * Converts checked exception to runtime exception so that no mandatory try-catch is required.
+   */
+  private RuntimeException toRuntimeException(Exception e) {
+    return new RuntimeException(e);
   }
 }

--- a/noodle/src/test/groovy/com/noodle/storage/EncryptedStorageSpec.groovy
+++ b/noodle/src/test/groovy/com/noodle/storage/EncryptedStorageSpec.groovy
@@ -50,7 +50,7 @@ class EncryptedStorageSpec extends RoboSpecification {
     storage.put(new Record(keyBytes, dataBytes))
 
     then:
-    1 * mockEncryption.encrypt(keyBytes) >> keyBytes
+    0 * mockEncryption.encrypt(keyBytes) >> keyBytes
     1 * mockEncryption.encrypt(dataBytes) >> dataBytes
 
   }
@@ -73,7 +73,7 @@ class EncryptedStorageSpec extends RoboSpecification {
     storage.get(keyBytes)
 
     then:
-    1 * mockEncryption.decrypt(keyBytes) >> keyBytes
+    0 * mockEncryption.decrypt(keyBytes) >> keyBytes
     1 * mockEncryption.decrypt(dataBytes) >> dataBytes
 
   }


### PR DESCRIPTION
Fixes decryption issue after app re-start: encrypt and decrypt only value, but not key.
    
It's ok to _not_ encrypt _key_ as it's _not secret_, but only _value_ is the _secret_.

Otherwise key is stored _un-encrypted_ in the memory cache (index) and _encrypted_ in the
  storage/file.

Later (after app re-start) when key is searched in .get()/.remove() -
   - it's searches for _unencrypted_ key,
   - but it's stored as _encrypted_ key in storage and on new re-start is read as _encrypted_ key  in memory cache (index)
   - thus _no value_ could be found.

 
`+` Tests are updated accordingly
